### PR TITLE
Update Existing Build Artifact Removal Logic

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -105,13 +105,9 @@ travis_start "gcp_rm"
 gsutil ls gs://$DEPLOY_BUCKET/$target | \
 while read -r line
 do
-    if [[ $line != CommandException* ]]; then
-      filename=`echo "$line" | awk -F'[[:space:]][[:space:]]' '{print $3}'`
-      if [[ $filename != "" ]]
-      then
-          echo "Deleting existing artifact gs://$DEPLOY_BUCKET/$filename."
-          gs rm gs://$DEPLOY_BUCKET/$filename
-      fi
+    if [[ $line != CommandException* ]] && [[ $line != "" ]]; then
+        echo "Deleting existing artifact [$line]."
+        gsutil rm $line
     fi
 done
 travis_end


### PR DESCRIPTION
The `gsutil ls` command is returning the fully qualified path for the objects in google storage, so the `awk` command is always filtering everything out.

Ex, using the path for a recent build, I can see 3 existing build artifacts. I have redacted the bucket name and replaced it with `[REDACTED]`
```
gsutil ls gs://[REDACTED]/builds/pull-request/4/
gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+15.war
gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+16.war
gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+17.war
```

Testing out the new logic has everything looking good.

Testing with valid output:
```
$ echo -e "gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+15.war\ngs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+16.war\ngs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+17.war" | \
> while read -r line
> do
>     if [[ $line != CommandException* ]] && [[ $line != "" ]]; then
>         echo "Deleting existing artifact [$line]."
>     fi
> done
Deleting existing artifact [gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+15.war].
Deleting existing artifact [gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+16.war].
Deleting existing artifact [gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+17.war].
```

Testing with blank lines:
```
$ echo -e "" | \
> while read -r line
> do
>     if [[ $line != CommandException* ]] && [[ $line != "" ]]; then
>         echo "Deleting existing artifact [$line]."
>     fi
> done
```
(no output)

Testing with example command failures:
```
$ echo -e 'CommandException: "ls" command does not support "file://" URLs. Did you mean to use a gs:// URL?' | \
> while read -r line
> do
>     if [[ $line != CommandException* ]] && [[ $line != "" ]]; then
>         echo "Deleting existing artifact [$line]."
>     fi
> done
```
(no output)

Testing with delete:
```
$ echo -e "gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+15.war" | \
> while read -r line
> do
>     if [[ $line != CommandException* ]] && [[ $line != "" ]]; then
>         echo "Deleting existing artifact [$line]."
>         gsutil rm $line
>     fi
> done
Deleting existing artifact [gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+15.war].
Removing gs://[REDACTED]/builds/pull-request/4/site-1.0.0-PR4+15.war...
/ [1 objects]
Operation completed over 1 objects.

```